### PR TITLE
UniformPDF evalutaion: Weight is equal to 1

### DIFF
--- a/source/ChargedParticle.cc
+++ b/source/ChargedParticle.cc
@@ -94,10 +94,11 @@ void ChargedParticle::PIDReconstruction(CherenkovPID &pid)
 	  
 	  // NB: y0 & y1 values do not matter; what matters is that they were equidistant 
 	  // in the previous loop; FIXME: add some smearing later;
-	  //photon->_m_PDF[radiator].AddMember(new UniformPDF(s0.GetTheta(), s1.GetTheta(), 1.0));
+	  photon->_m_PDF[radiator].AddMember(new UniformPDF(s0.GetTheta(), s1.GetTheta(), 1.0));
 	  //printf("%2d -> %7.3f\n", iq, weights[iq]);
-	  photon->_m_PDF[radiator].AddMember(new UniformPDF(s0.GetTheta(), s1.GetTheta(), 
-							    (weights[iq] + weights[iq+1])/2));//1.0));
+	  /*photon->_m_PDF[radiator].AddMember(new UniformPDF(s0.GetTheta(), s1.GetTheta(), 
+							    (weights[iq] + weights[iq+1])/2)); *///1.0));
+	  //printf("%2d -> %7.3f\n", iq, weights[iq]);
 	  //photon->_m_PDF[radiator].AddMember(new UniformPDF(s0.GetTheta(), s1.GetTheta(), fabs(cos(s0.GetPhi()))));
 	} //for iq
       }


### PR DESCRIPTION
I have modified the UniformPDF to estimate the Cherenkov theta for gases. 
Now the zbins solutions are treated with weight 1.0
