### PR TITLE
feat: support external readout ID-to-position converter

### DIFF
--- a/include/CherenkovDetector.h
+++ b/include/CherenkovDetector.h
@@ -115,6 +115,12 @@ class CherenkovDetector: public TObject {
     return 0;
   };
 
+  // readout ID -> pixel position converter (overridable externally)
+  std::function<TVector3(long long int)> m_ReadoutIDToPosition = [] (long long int i) {
+    fprintf(stderr,"ERROR: CherenkovRadiator::m_ReadoutIDToPosition not defined\n");
+    return TVector3(0.,0.,0.);
+  };
+
  private:  
   TString m_Name;
   // This is needed for dd4hep cell index decoding;


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Add `std::function` member to `CherenkovDetector`, to hold a function that converts a sensor/pixel/readout ID to a position. This member is meant to be overridden (and used) externally.
(FYI @alexander-kiselev)

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
no
### Does this PR change default behavior?
no