### PR TITLE
fix: prevent `CherenkovDetector::m_ReadoutIDToPosition` from being written

### DIFF
--- a/include/CherenkovDetector.h
+++ b/include/CherenkovDetector.h
@@ -115,11 +115,8 @@ class CherenkovDetector: public TObject {
     return 0;
   };
 
-  // readout ID -> pixel position converter (overridable externally)
-  std::function<TVector3(long long int)> m_ReadoutIDToPosition = [] (long long int i) {
-    fprintf(stderr,"ERROR: CherenkovRadiator::m_ReadoutIDToPosition not defined\n");
-    return TVector3(0.,0.,0.);
-  };
+  // readout ID -> pixel position converter (for external usage)
+  std::function<TVector3(long long int)> m_ReadoutIDToPosition; //!
 
  private:  
   TString m_Name;


### PR DESCRIPTION
### Briefly, what does this PR introduce?
`std::function` cannot be written to ROOT file, and we do not need it since this member is only used on-the-fly by `EICrecon`.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
no

### Does this PR change default behavior?
no