### PR TITLE
fix: `G4Object` inclusion

### DIFF
--- a/include/CherenkovMirror.h
+++ b/include/CherenkovMirror.h
@@ -2,7 +2,7 @@
 #ifndef _CHERENKOV_MIRROR_
 #define _CHERENKOV_MIRROR_
 
-#include <G4Object.h>
+#include "G4Object.h"
 #include "ParametricSurface.h"
 
 class SurfaceCopy: public G4ObjectCopy {

--- a/include/CherenkovPhotonDetector.h
+++ b/include/CherenkovPhotonDetector.h
@@ -4,7 +4,7 @@
 #ifndef _CHERENKOV_PHOTON_DETECTOR_
 #define _CHERENKOV_PHOTON_DETECTOR_
 
-#include <G4Object.h>
+#include "G4Object.h"
 #include "ParametricSurface.h"
 
 class G4DataInterpolation;


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Fixes
```
'G4Object.h' file not found with <angled> include; use "quotes" instead
#include <G4Object.h>
```
Thanks @DraTeots for spotting this bug!

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
no

### Does this PR change default behavior?
no