### PR TITLE
fix memory leak in VectorPDF

### DIFF
--- a/include/SinglePDF.h
+++ b/include/SinglePDF.h
@@ -81,7 +81,11 @@ class UniformPDF: public SinglePDF {
 class VectorPDF: public TObject {
  public:
   VectorPDF() {};
-  ~VectorPDF() {};
+  ~VectorPDF() {
+    for(auto pdf : m_Members) {
+      delete pdf;
+    }
+  };
   
   void AddMember(UniformPDF *pdf) { m_Members.push_back(pdf); };
   unsigned GetWithinRangeCount(double x, double dx = 0.0) const {


### PR DESCRIPTION
Resolves: https://github.com/eic/EICrecon/issues/1456

cc #36 