### PR TITLE
CMakeLists.txt: update IRT version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.0.0 FATAL_ERROR)
 
 project(IRT2
-  VERSION 2.1.0
+  VERSION 2.1.2
   LANGUAGES CXX
 )
 


### PR DESCRIPTION
This is needed because downstream we now https://github.com/eic/epic/pull/1041 require IRT2 2.1.1 or older. The 2.1.1 still pretends to be 2.1.0, unfortunately.