### PR TITLE
build: fix various cmake issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10.0 FATAL_ERROR)
 
 project(IRT2
   VERSION 2.1.3

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,9 +149,9 @@ endif()
 
 # linking
 if(JSON_EXPORT)
-  target_link_libraries(${CMAKE_PROJECT_NAME} ROOT::Core ROOT::EG ROOT::Hist ROOT::RIO ROOT::MathCore ROOT::Tree nlohmann_json::nlohmann_json)
-elseif()
-  target_link_libraries(${CMAKE_PROJECT_NAME} ROOT::Core ROOT::EG ROOT::Hist ROOT::RIO ROOT::MathCore ROOT::Tree)
+  target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC ROOT::Core ROOT::EG ROOT::Hist ROOT::RIO ROOT::MathCore ROOT::Tree PRIVATE nlohmann_json::nlohmann_json)
+else()
+  target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC ROOT::Core ROOT::EG ROOT::Hist ROOT::RIO ROOT::MathCore ROOT::Tree)
 endif()
 #----------------------------------------------------------------------------
 # optional targets

--- a/delphes/CMakeLists.txt
+++ b/delphes/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-cmake_minimum_required(VERSION 3.0.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10.0 FATAL_ERROR)
 
 project(DELPHES)
 

--- a/evaluation/CMakeLists.txt
+++ b/evaluation/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-cmake_minimum_required(VERSION 3.0.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10.0 FATAL_ERROR)
 
 project(EVALUATION)
 


### PR DESCRIPTION
# CMake 4 compatibility
Current variant fails with CMake 4:
```
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.

-- Configuring incomplete, errors occurred!
```
# Missing ROOT library linking when JSON is disabled
```
CMake Warning (dev) at CMakeLists.txt:153 (elseif):
  ELSEIF called with no arguments, it will be skipped.
This warning is for project developers.  Use -Wno-dev to suppress it.
```
# nlohmann issue
Described in https://github.com/eic/irt/pull/53#discussion_r2848817174