### PR TITLE
fix: enable JSON export of compile commands

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,9 @@ option(USE_TSAN "Enable Thread Sanitizer" OFF)
 cmake_dependent_option(USE_ASAN "Enable Address Sanitizer" OFF "NOT USE_TSAN" OFF)
 cmake_dependent_option(USE_UBSAN "Enable Undefined Behavior Sanitizer" OFF "NOT USE_TSAN" OFF)
 
+# Export compile commands as json for run-clang-tidy
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 #----------------------------------------------------------------------------
 # dependencies
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ option(USE_TSAN "Enable Thread Sanitizer" OFF)
 cmake_dependent_option(USE_ASAN "Enable Address Sanitizer" OFF "NOT USE_TSAN" OFF)
 cmake_dependent_option(USE_UBSAN "Enable Undefined Behavior Sanitizer" OFF "NOT USE_TSAN" OFF)
 
-# Export compile commands as json for run-clang-tidy
+# Export compile commands as JSON (compile_commands.json) for run-clang-tidy
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 #----------------------------------------------------------------------------


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR enables exporting of compile commands in JSON format for tools like clang-tidy.

### What is the urgency of this PR?
- [x] High (please describe reason below)
- [ ] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue: main clang-tidy broken)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.

Currently broken on main.